### PR TITLE
Fix white flash on root URL redirect

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,3 +1,1 @@
----
-return Astro.redirect('/fr');
----
+<!DOCTYPE html><html><head><meta charset="utf-8"><meta http-equiv="refresh" content="0;url=/fr/"><link rel="canonical" href="/fr/"></head><body></body></html>


### PR DESCRIPTION
## Summary
- Replace `Astro.redirect('/fr')` with a minimal HTML meta refresh redirect
- Eliminates the visible "Redirecting to..." flash that appeared when visiting the root URL
- Uses `content="0"` (zero delay) and an empty `<body>` for an instant, invisible redirect

## Test plan
- [ ] Visit the root URL (https://testing.africanpuzzle.com/) and confirm no white flash
- [ ] Confirm redirect lands on `/fr/` correctly
- [ ] Verify SEO: canonical link points to `/fr/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)