### PR TITLE
Fix GIF content gaps inside phone device mockups

### DIFF
--- a/src/components/ui/PhoneFrame.astro
+++ b/src/components/ui/PhoneFrame.astro
@@ -18,16 +18,18 @@ const { src, alt, class: className = '' } = Astro.props;
     position: relative;
     width: 220px;
     aspect-ratio: 409 / 855;
+    background: #000;
+    border-radius: 2.5rem;
   }
 
   .phone-screen {
     position: absolute;
-    top: 6.55%;
-    left: 6.6%;
-    width: 87.8%;
-    height: 86.4%;
+    top: 5.5%;
+    left: 5.5%;
+    width: 90%;
+    height: 88%;
     object-fit: cover;
-    border-radius: 1.5rem;
+    border-radius: 2rem;
   }
 
   .phone-bezel {


### PR DESCRIPTION
Adds black background to the phone frame container to mask sub-pixel rendering gaps between the GIF and device bezel overlay. Expands the GIF screen area positioning (top: 5.5%, left: 5.5%, width: 90%, height: 88%) to better fill the available space while keeping the bezel on top to cover any remaining gaps.

Resolves #11