### PR TITLE
Wrap countries.json bare array for CMS compatibility (closes #15)

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -36,7 +36,7 @@ const features = defineCollection({
 });
 
 const countries = defineCollection({
-  loader: file('src/content/countries/countries.json'),
+  loader: file('src/content/countries/countries.json', { parser: (text) => JSON.parse(text).countries }),
   schema: z.object({
     emoji: z.string(),
     fr: z.string(),

--- a/src/content/countries/countries.json
+++ b/src/content/countries/countries.json
@@ -1,4 +1,5 @@
-[
+{
+  "countries": [
   { "id": "algeria", "emoji": "🇩🇿", "fr": "Algérie", "en": "Algeria", "pcm": "Algeria" },
   { "id": "austria", "emoji": "🇦🇹", "fr": "Autriche", "en": "Austria", "pcm": "Austria" },
   { "id": "belgium", "emoji": "🇧🇪", "fr": "Belgique", "en": "Belgium", "pcm": "Belgium" },
@@ -70,4 +71,5 @@
   { "id": "united-states", "emoji": "🇺🇸", "fr": "États-Unis d'Amérique", "en": "United States", "pcm": "United States" },
   { "id": "zambia", "emoji": "🇿🇲", "fr": "Zambie", "en": "Zambia", "pcm": "Zambia" },
   { "id": "zimbabwe", "emoji": "🇿🇼", "fr": "Zimbabwe", "en": "Zimbabwe", "pcm": "Zimbabwe" }
-]
+  ]
+}


### PR DESCRIPTION
## Summary
- Wraps `src/content/countries/countries.json` bare array in `{ "countries": [...] }` to satisfy Sveltia CMS `files` collection requirement for object-structured JSON
- Adds a `parser` to the Astro `file()` loader to extract the `countries` array, keeping all 71 country entries and build output unchanged
- `npm run build` passes successfully

## Test plan
- [x] `npm run build` succeeds (17 pages built)
- [x] All 71 countries unchanged — only outer JSON structure modified
- [ ] Verify countries grid renders on homepage after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)