### PR TITLE
Move About page images to CMS settings (fixes #18)

### DIFF
--- a/src/components/sections/AboutContent.astro
+++ b/src/components/sections/AboutContent.astro
@@ -1,6 +1,7 @@
 ---
 import { t, type Locale } from '../../i18n/utils';
 import { getCollection } from 'astro:content';
+import aboutPage from '../../content/settings/about-page.json';
 
 interface Props {
   lang: Locale;
@@ -18,7 +19,7 @@ const team = teamEntries
   <!-- Full-bleed hero -->
   <div class="relative w-full h-[60vh] md:h-[80vh] lg:h-screen overflow-hidden">
     <img
-      src="/images/about-hero.png"
+      src={aboutPage.heroImage}
       alt="African Puzzle"
       class="absolute inset-0 w-full h-full object-cover"
     />
@@ -53,7 +54,7 @@ const team = teamEntries
         <div class="relative flex-shrink-0 px-8 lg:px-12 my-4 lg:my-0">
           <div class="lg:my-[-4rem]">
             <img
-              src="/images/app-screenshot-programmes.png"
+              src={aboutPage.phoneMockupImage}
               alt="African Puzzle WORKS app"
               class="w-56 md:w-64 lg:w-72 drop-shadow-2xl"
             />

--- a/src/content/settings/about-page.json
+++ b/src/content/settings/about-page.json
@@ -1,0 +1,4 @@
+{
+  "heroImage": "/images/about-hero.png",
+  "phoneMockupImage": "/images/app-screenshot-programmes.png"
+}


### PR DESCRIPTION
## Summary
- Created `src/content/settings/about-page.json` with `heroImage` and `phoneMockupImage` fields
- Updated `AboutContent.astro` to load images from the new settings file instead of hardcoding paths
- Follows the existing pattern used by `site.json`

## Verification
The About page renders identically to before. No hardcoded image paths remain in the component.

📱 Generated with Claude Code