### PR TITLE
Improve About page readability: contrast, font sizes, background

### DIFF
--- a/src/components/sections/AboutContent.astro
+++ b/src/components/sections/AboutContent.astro
@@ -15,7 +15,7 @@ const team = teamEntries
   .map(entry => entry.data);
 ---
 
-<section class="pb-20 lg:pb-28 bg-about-tan">
+<section class="pb-20 lg:pb-28 bg-about-bg">
   <!-- Full-bleed hero -->
   <div class="relative w-full h-[60vh] md:h-[80vh] lg:h-screen overflow-hidden">
     <img
@@ -65,7 +65,7 @@ const team = teamEntries
 
     <!-- Team -->
     <div class="text-center mb-12">
-      <h2 class="text-3xl font-bold font-display text-[#340975]">
+      <h2 class="text-3xl font-bold font-display text-about-name">
         {t(lang, 'about.team_title')}
       </h2>
     </div>
@@ -73,7 +73,7 @@ const team = teamEntries
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
       {team.map((member) => (
         <div class="text-center group">
-          <div class="relative w-40 h-40 lg:w-[260px] lg:h-[260px] mx-auto mb-4 rounded-full bg-white flex items-center justify-center text-[#340975] text-3xl lg:text-5xl font-bold overflow-hidden shadow-lg group-hover:shadow-xl transition-shadow duration-300">
+          <div class="relative w-40 h-40 lg:w-[260px] lg:h-[260px] mx-auto mb-4 rounded-full bg-white flex items-center justify-center text-about-name text-3xl lg:text-5xl font-bold overflow-hidden shadow-lg group-hover:shadow-xl transition-shadow duration-300">
             <span>{member.name.split(' ').map(n => n[0]).join('')}</span>
             <img
               src={member.photo}
@@ -82,11 +82,11 @@ const team = teamEntries
               onerror="this.style.display='none'"
             />
           </div>
-          <h3 class="font-bold text-[#340975] text-lg">
+          <h3 class="font-bold text-about-name text-lg">
             {member.name}
           </h3>
           {member.role[lang] && (
-            <p class="text-sm text-[#a5a29b] mt-1">
+            <p class="text-base text-about-role mt-1">
               {member.role[lang]}
             </p>
           )}
@@ -95,7 +95,7 @@ const team = teamEntries
               href={member.linkedin}
               target="_blank"
               rel="noopener noreferrer"
-              class="inline-flex items-center gap-1 mt-3 text-sm text-[#340975] hover:text-[#340975]/70 transition-colors"
+              class="inline-flex items-center gap-1 mt-3 text-base text-about-name hover:text-about-name/70 transition-colors"
             >
               LinkedIn
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -19,9 +19,9 @@
   --color-feature-clients: #c5bed1;
   --color-feature-album: #ffba42;
   --color-feature-appointments: #aad3fa;
-  --color-about-tan: #eae0ab;
+  --color-about-bg: #f3f4f6;
   --color-about-name: #340975;
-  --color-about-role: #a5a29b;
+  --color-about-role: #4b5563;
 
   --font-sans: 'Montserrat', system-ui, sans-serif;
   --font-display: 'Nunito', system-ui, sans-serif;

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -30,9 +30,9 @@ export default {
           appointments: '#aad3fa',
         },
         about: {
-          tan: '#eae0ab',
+          bg: '#f3f4f6',
           name: '#340975',
-          role: '#a5a29b',
+          role: '#4b5563',
         },
       },
       fontFamily: {


### PR DESCRIPTION
## Summary
- Changed page background from tan (`#eae0ab`) to light grey (`#f3f4f6`) for better text contrast
- Updated team member role text color from `#a5a29b` to `#4b5563` (WCAG AA compliant ~7:1 ratio)
- Increased minimum font size to 16px (`text-base`) on role text and LinkedIn links
- Replaced all hardcoded `#340975` hex values with `text-about-name` design tokens

## Test plan
- [ ] Verify light grey background on `/fr/a-propos/`, `/en/about/`, `/pcm/about/`
- [ ] Confirm all text is ≥16px (no `text-sm` or `text-xs` classes remain)
- [ ] Check team role text contrast against background meets WCAG AA (≥4.5:1)
- [ ] Verify `npm run build` succeeds

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)